### PR TITLE
fix: Estimated wrong page count because of this

### DIFF
--- a/src/Service/PaginationFactory.php
+++ b/src/Service/PaginationFactory.php
@@ -39,10 +39,6 @@ class PaginationFactory
     {
         $last = (int) ceil($count / $perPage);
 
-        if (0 === $count % 10) {
-            return --$last;
-        }
-
         if (0 === $last) {
             return 1;
         }


### PR DESCRIPTION
Fixing #781 with this PR, because of a strange constraint to the calculation of the last page in the Paginator.