### PR TITLE
fix: Made SpecialityDetail in Allocations optional

### DIFF
--- a/migrations/Version20220331102155.php
+++ b/migrations/Version20220331102155.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220331102155 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE allocation CHANGE speciality_detail speciality_detail VARCHAR(50) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE allocation CHANGE speciality_detail speciality_detail VARCHAR(50) NOT NULL');
+    }
+}

--- a/src/Domain/Contracts/AllocationInterface.php
+++ b/src/Domain/Contracts/AllocationInterface.php
@@ -132,7 +132,7 @@ interface AllocationInterface
 
     public function setSpecialityDetail(string $specialityDetail): self;
 
-    public function getSpecialityDetail(): string;
+    public function getSpecialityDetail(): ?string;
 
     public function setSpecialityWasClosed(bool $specialityWasClosed): self;
 

--- a/src/Domain/Entity/Allocation.php
+++ b/src/Domain/Entity/Allocation.php
@@ -103,7 +103,7 @@ class Allocation implements AllocationInterface, IdentifierInterface
 
     protected string $speciality;
 
-    protected string $specialityDetail;
+    protected ?string $specialityDetail = null;
 
     protected bool $specialityWasClosed;
 
@@ -525,7 +525,7 @@ class Allocation implements AllocationInterface, IdentifierInterface
         return $this;
     }
 
-    public function getSpecialityDetail(): string
+    public function getSpecialityDetail(): ?string
     {
         return $this->specialityDetail;
     }

--- a/src/Entity/Allocation.php
+++ b/src/Entity/Allocation.php
@@ -259,10 +259,9 @@ class Allocation extends DomainAllocation
     protected string $speciality;
 
     /**
-     * @ORM\Column(type="string", length=50)
+     * @ORM\Column(type="string", length=50, nullable=true)
      */
-    #[Assert\NotBlank(message: 'The specialityDetail must not be empty.')]
-    protected string $specialityDetail;
+    protected ?string $specialityDetail = null;
 
     /**
      * @ORM\Column(type="boolean")

--- a/templates/allocation/show.html.twig
+++ b/templates/allocation/show.html.twig
@@ -91,9 +91,7 @@
                                 {{ allocation.speciality }}
                             </p>
                         </div>
-                        {% if
-                            allocation.speciality
-                                != allocation.specialityDetail %}
+                        {% if allocation.specialityDetail %}
                             <div class="col-6">
                                 <h5 class="card-title">
                                     {{


### PR DESCRIPTION
It has become obvious that in some places it is quite common not to set the SpecialityDetail for all Allocations, so that some imports end up having a lot of rows sorted out by the ImportWriter. Therefore I've made it optional to add this data to the entity.