### PR TITLE
Removed support for Coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-coverage_clover: var/build/coverage/logs/clover.xml
-json_path: var/build/coverage/logs/coveralls-upload.json

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -133,14 +133,6 @@ jobs:
               env:
                   DATABASE_URL: mysql://root:symfony@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/symfony
 
-            - name: Upload coverage results to Coveralls
-              if: ${{ github.actor != 'dependabot[bot]' }}
-              env:
-                  COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  composer global require php-coveralls/php-coveralls
-                  php-coveralls --coverage_clover=var/build/coverage/logs/clover.xml -v
-
             - name: Upload coverage to Codeclimate
               if: ${{ github.actor != 'dependabot[bot]' }}
               uses: paambaati/codeclimate-action@v3.0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # COIS - Collaborative IVENA statistics
 
-[![Continuous Integration](https://github.com/nplhse/cois/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/nplhse/cois/actions/workflows/continuous-integration.yml) [![Coverage Status](https://coveralls.io/repos/github/nplhse/cois/badge.svg?branch=main)](https://coveralls.io/github/nplhse/cois?branch=main) [![Maintainability](https://api.codeclimate.com/v1/badges/42c306c963c6a04bd2ea/maintainability)](https://codeclimate.com/github/nplhse/cois/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/42c306c963c6a04bd2ea/test_coverage)](https://codeclimate.com/github/nplhse/cois/test_coverage)
+[![Continuous Integration](https://github.com/nplhse/cois/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/nplhse/cois/actions/workflows/continuous-integration.yml) [![Test Coverage](https://api.codeclimate.com/v1/badges/42c306c963c6a04bd2ea/test_coverage)](https://codeclimate.com/github/nplhse/cois/test_coverage) [![Maintainability](https://api.codeclimate.com/v1/badges/42c306c963c6a04bd2ea/maintainability)](https://codeclimate.com/github/nplhse/cois/maintainability)
 
 # Requirements
 


### PR DESCRIPTION
Somehow submission of code coverage to Coveralls stopped working (see #1056). When I've investigated this issue I couldn't find an obvious error... But It's not really necessary because Code Climate also supplies a coverage badge.