### PR TITLE
feat: Added recent posts to sidebar

### DIFF
--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -272,7 +272,11 @@
                 </div>
             </div>
 
-            <div class="p-2 mt-4">
+            <div class="p-4 mb-3 bg-light rounded">
+                <div class="mb-4">
+                    {{ component('recent_posts') }}
+                </div>
+
                 {{ component('page_menu') }}
             </div>
         </div>

--- a/tests/Application/Controller/Settings/User/ProfileControllerTest.php
+++ b/tests/Application/Controller/Settings/User/ProfileControllerTest.php
@@ -18,7 +18,7 @@ class ProfileControllerTest extends WebTestCase
     {
         $this->markTestSkipped();
 
-        /**
+        /*
         $userRepository = static::getContainer()->get(UserRepository::class);
         $testUser = $userRepository->findOneBy(['username' => 'foo']);
 


### PR DESCRIPTION
It would be a good idea to add the recent posts to a special block in the sidebar of the dashboard, this PR does this. It adds a nice grey box (like the "about" section of pages and posts) to the sidebar below the statistics.