### PR TITLE
fix: Only select users who are hospital owners

### DIFF
--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -142,9 +142,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
     public function findHospitalOwners(): array
     {
         $qb = $this->createQueryBuilder('u')
-            ->leftJoin('u.hospitals', 'h')
-            ->orderBy('u.id', \Doctrine\Common\Collections\Criteria::ASC)
-            ->distinct()
+            ->where('SIZE(u.hospitals) > 0')
             ->getQuery()
             ->execute();
 


### PR DESCRIPTION
Currently we don't really select users ho are hospital owners to send the monthly reminder, this PR is changing that.