### PR TITLE
Fix import date format giessen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ messenger:
 	@$(SYMFONY) messenger:consume async -vvv
 
 phpcsfixer:
-	vendor/bin/php-cs-fixer fix
+	PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix
 
 phpmd:
 	vendor/bin/phpmd src/ html phpmd.xml --report-file var/build/phpmd.html --ignore-violations-on-exit

--- a/src/Controller/Admin/PageCrudController.php
+++ b/src/Controller/Admin/PageCrudController.php
@@ -42,19 +42,19 @@ class PageCrudController extends AbstractCrudController
                 ->setFormType(EnumType::class)
                 ->setFormTypeOption('class', PageType::class)
                 ->setChoices([
-                    'Type' => PageType::cases()
+                    'Type' => PageType::cases(),
                 ]),
             ChoiceField::new('status')->onlyOnForms()
                 ->setFormType(EnumType::class)
                 ->setFormTypeOption('class', PageStatus::class)
                 ->setChoices([
-                    'Status' => PageStatus::cases()
+                    'Status' => PageStatus::cases(),
                 ]),
             ChoiceField::new('visibility')->onlyOnForms()
                 ->setFormType(EnumType::class)
                 ->setFormTypeOption('class', PageVisbility::class)
                 ->setChoices([
-                    'Visibility' => PageVisbility::cases()
+                    'Visibility' => PageVisbility::cases(),
                 ]),
             DateField::new('createdAt')
                 ->hideOnForm(),

--- a/src/Controller/Admin/PostCrudController.php
+++ b/src/Controller/Admin/PostCrudController.php
@@ -43,7 +43,7 @@ class PostCrudController extends AbstractCrudController
                 ->setFormType(EnumType::class)
                 ->setFormTypeOption('class', PostStatus::class)
                 ->setChoices([
-                    'Status' => PostStatus::cases()
+                    'Status' => PostStatus::cases(),
                 ]),
             BooleanField::new('isSticky')->hideOnIndex(),
             BooleanField::new('allowComments')->hideOnIndex(),

--- a/src/Service/Import/Writer/Allocation/AllocationPropertyImportWriter.php
+++ b/src/Service/Import/Writer/Allocation/AllocationPropertyImportWriter.php
@@ -52,8 +52,14 @@ class AllocationPropertyImportWriter implements \App\Application\Contract\Alloca
 
     public function setTimes(Allocation $allocation, array $row): Allocation
     {
-        $allocation->setCreatedAt(new \DateTime($row['Datum (Erstellungsdatum)'].' '.$row['Uhrzeit (Erstellungsdatum)']));
-        $allocation->setArrivalAt(new \DateTime($row['Datum (Eintreffzeit)'].' '.$row['Uhrzeit (Eintreffzeit)']));
+        $format = "d.m.Y H:i:s";
+
+        if (strlen($row['Datum (Erstellungsdatum)']) === 8) {
+            $format = "d.m.y H:i:s";
+        }
+
+        $allocation->setCreatedAt(\DateTime::createFromFormat($format, $row['Datum (Erstellungsdatum)'].' '.$row['Uhrzeit (Erstellungsdatum)'], new \DateTimeZone('Europe/Berlin')));
+        $allocation->setArrivalAt(\DateTime::createFromFormat($format, $row['Datum (Eintreffzeit)'].' '.$row['Uhrzeit (Eintreffzeit)'], new \DateTimeZone('Europe/Berlin')));
 
         return $allocation;
     }

--- a/src/Service/Import/Writer/Allocation/AllocationPropertyImportWriter.php
+++ b/src/Service/Import/Writer/Allocation/AllocationPropertyImportWriter.php
@@ -52,10 +52,10 @@ class AllocationPropertyImportWriter implements \App\Application\Contract\Alloca
 
     public function setTimes(Allocation $allocation, array $row): Allocation
     {
-        $format = "d.m.Y H:i:s";
+        $format = 'd.m.Y H:i:s';
 
-        if (strlen($row['Datum (Erstellungsdatum)']) === 8) {
-            $format = "d.m.y H:i:s";
+        if (8 === strlen($row['Datum (Erstellungsdatum)'])) {
+            $format = 'd.m.y H:i:s';
         }
 
         $allocation->setCreatedAt(\DateTime::createFromFormat($format, $row['Datum (Erstellungsdatum)'].' '.$row['Uhrzeit (Erstellungsdatum)'], new \DateTimeZone('Europe/Berlin')));


### PR DESCRIPTION
There was an issue where Imports from Giessen didn't work and threw an error regarding the date format. Turns out they used "d.m.y" as format and not "d.m.Y" as everyone else was doing and this caused DateTime to fail. Now there is a check of the length of the date string and the format gets adjusted to that, so that both ways are supported.